### PR TITLE
fix: remove incorrect self-call to Safe.enableModule

### DIFF
--- a/contracts/ZkSafePrivateOwnersModule.sol
+++ b/contracts/ZkSafePrivateOwnersModule.sol
@@ -53,12 +53,7 @@ contract ZkSafePrivateOwnersModule {
      * @param threshold Number of required confirmations for a zkSafe transaction.
     */
     function enableModule(bytes32 ownersRoot, uint256 threshold) external {
-        address payable thisAddr = payable(address(this));
-        Safe(thisAddr).enableModule(zkSafeModuleAddress);
-
-        // Initialize zkMultisg config
-        ZkSafePrivateOwnersModule(zkSafeModuleAddress)
-            .updateZkMultisigConf(ownersRoot, threshold);
+        updateZkMultisigConf(ownersRoot, threshold);
     }
 
      /*


### PR DESCRIPTION
Remove incorrect self-call to Safe.enableModule in enableModule(). Module enabling should be performed by the Safe contract itself.